### PR TITLE
Fix narrowing conversion error

### DIFF
--- a/libcds/src/static/suffixtree/RMQ_succinct.cpp
+++ b/libcds/src/static/suffixtree/RMQ_succinct.cpp
@@ -112,7 +112,10 @@ namespace cds_static{
 		return c;
 	}
 
-	const DTsucc RMQ_succinct::HighestBitsSet[8] = {~0, ~1, ~3, ~7, ~15, ~31, ~63, ~127};
+	const DTsucc RMQ_succinct::HighestBitsSet[8] = {
+		DTsucc(~0), DTsucc(~1), DTsucc(~3), DTsucc(~7),
+		DTsucc(~15), DTsucc(~31), DTsucc(~63), DTsucc(~127)
+	};
 
 	DTsucc RMQ_succinct::clearbits(DTsucc n, unsigned int x) {
 		return n & HighestBitsSet[x];

--- a/libcds/src/static/suffixtree/RMQ_succinct_lcp.cpp
+++ b/libcds/src/static/suffixtree/RMQ_succinct_lcp.cpp
@@ -115,7 +115,10 @@ namespace cds_static{
 		return c;
 	}
 
-	const DTsucc RMQ_succinct_lcp::HighestBitsSet[8] = {~0, ~1, ~3, ~7, ~15, ~31, ~63, ~127};
+	const DTsucc RMQ_succinct_lcp::HighestBitsSet[8] = {
+		DTsucc(~0), DTsucc(~1), DTsucc(~3), DTsucc(~7),
+		DTsucc(~15), DTsucc(~31), DTsucc(~63), DTsucc(~127)
+	};
 
 	DTsucc RMQ_succinct_lcp::clearbits(DTsucc n, uint x) {
 			return n & HighestBitsSet[x];


### PR DESCRIPTION
Fixes #2.

Explicitly cast values to `DTsucc` to avoid error:
```
static/suffixtree/RMQ_succinct.cpp:115:85: error: narrowing conversion of ‘-1’ from ‘int’ to ‘DTsucc {aka unsigned char}’ inside { } [-Wnarrowing]
  const DTsucc RMQ_succinct::HighestBitsSet[8] = {~0, ~1, ~3, ~7, ~15, ~31, ~63, ~127};
```

This appears to be an error in C++11 and newer, which is typically
the default mode these days.